### PR TITLE
消费者如果返回uacked，开发人员可以自行指定是否需要重新入队。

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -204,7 +204,7 @@ class Consumer extends Builder
             }
             if ($result === Result::NACK) {
                 $this->logger->debug($deliveryTag . ' uacked.');
-                return $channel->basic_nack($deliveryTag);
+                return $channel->basic_nack($deliveryTag, false, $consumerMessage->isRequeue());
             }
             if ($consumerMessage->isRequeue() && $result === Result::REQUEUE) {
                 $this->logger->debug($deliveryTag . ' requeued.');


### PR DESCRIPTION
原因：rabbitmq有的ack机制下，uack可以在rabbitmq控制台中监控到重新入队的数量，可以给开发人员提供预警信息。直接requeue会是一条新的消息。另外消费者消费过程中如果服务挂了，消费中的信息一样是uack状态。
PhpAmqpLib封装方法public function basic_nack($delivery_tag, $multiple = false, $requeue = false)第三个参数就是为了让开发人员自行决定是否要unack后重新入队的。