### PR TITLE
Fixed: 修复通过hyperf获取amqp连接直接调用amqplib的consume方法获取 getReadTimeout() 异常

### DIFF
--- a/src/IO/SwooleIO.php
+++ b/src/IO/SwooleIO.php
@@ -138,4 +138,9 @@ class SwooleIO extends AbstractIO
     {
         return 1;
     }
+
+    public function getReadTimeout (): float
+    {
+        return $this->readWriteTimeout;
+    }
 }

--- a/src/IO/SwowIO.php
+++ b/src/IO/SwowIO.php
@@ -139,4 +139,9 @@ class SwowIO extends AbstractIO
     {
         return 1;
     }
+
+    public function getReadTimeout (): float
+    {
+        return $this->readWriteTimeout;
+    }
 }


### PR DESCRIPTION
Fixed: 修复通过hyperf获取amqp连接直接调用amqplib的consume方法获取 getReadTimeout() 异常